### PR TITLE
Adding code link for examples

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/commons/commons.dart
+++ b/lib/commons/commons.dart
@@ -1,0 +1,6 @@
+String baseLink(String path) {
+  const _basePath =
+      'https://github.com/flame-engine/flame_example/blob/master/lib/stories/';
+
+  return '$_basePath$path';
+}

--- a/lib/commons/dashbook_gamewidget.dart
+++ b/lib/commons/dashbook_gamewidget.dart
@@ -1,0 +1,19 @@
+import 'package:flame/game.dart';
+import 'package:flame/game/game_widget.dart';
+import 'package:flutter/widgets.dart';
+
+class DashbookGameWidget extends StatelessWidget {
+  final Game game;
+
+  DashbookGameWidget({this.game});
+
+  @override
+  Widget build(ctx) {
+    return Container(
+      padding: EdgeInsets.only(top: 50),
+      child: ClipRect(
+        child: GameWidget(game: game),
+      ),
+    );
+  }
+}

--- a/lib/stories/animations/animations.dart
+++ b/lib/stories/animations/animations.dart
@@ -3,19 +3,18 @@ import 'package:dashbook/dashbook.dart';
 import './basic.dart';
 import './aseprite.dart';
 import '../../commons/dashbook_gamewidget.dart';
+import '../../commons/commons.dart';
 
 void addAnimationStories(Dashbook dashbook) {
   dashbook.storiesOf('Animations')
     ..add(
       'basic animations',
       (_) => DashbookGameWidget(game: BasicAnimations()),
-      codeLink:
-          'https://github.com/flame-engine/flame_example/blob/master/lib/stories/animations/basic.dart',
+      codeLink: baseLink('animations/basic.dart'),
     )
     ..add(
       'aseprite',
       (_) => DashbookGameWidget(game: Aseprite()),
-      codeLink:
-          'https://github.com/flame-engine/flame_example/blob/master/lib/stories/animations/aseprite.dart',
+      codeLink: baseLink('animations/aseprite.dart'),
     );
 }

--- a/lib/stories/animations/animations.dart
+++ b/lib/stories/animations/animations.dart
@@ -1,11 +1,21 @@
 import 'package:dashbook/dashbook.dart';
-import 'package:flame/game/game_widget.dart';
 
 import './basic.dart';
 import './aseprite.dart';
+import '../../commons/dashbook_gamewidget.dart';
 
 void addAnimationStories(Dashbook dashbook) {
   dashbook.storiesOf('Animations')
-    ..add('basic animations', (_) => GameWidget(game: BasicAnimations()))
-    ..add('aseprite', (_) => GameWidget(game: Aseprite()));
+    ..add(
+      'basic animations',
+      (_) => DashbookGameWidget(game: BasicAnimations()),
+      codeLink:
+          'https://github.com/flame-engine/flame_example/blob/master/lib/stories/animations/basic.dart',
+    )
+    ..add(
+      'aseprite',
+      (_) => DashbookGameWidget(game: Aseprite()),
+      codeLink:
+          'https://github.com/flame-engine/flame_example/blob/master/lib/stories/animations/aseprite.dart',
+    );
 }

--- a/lib/stories/components/components.dart
+++ b/lib/stories/components/components.dart
@@ -1,11 +1,21 @@
 import 'package:dashbook/dashbook.dart';
-import 'package:flame/game/game_widget.dart';
 
 import './composability.dart';
 import './debug.dart';
+import '../../commons/dashbook_gamewidget.dart';
 
 void addComponentsStories(Dashbook dashbook) {
   dashbook.storiesOf('Components')
-    ..add('composability', (_) => GameWidget(game: Composability()))
-    ..add('debug', (_) => GameWidget(game: Debug()));
+    ..add(
+      'composability',
+      (_) => DashbookGameWidget(game: Composability()),
+      codeLink:
+          'https://github.com/flame-engine/flame_example/blob/master/lib/stories/components/composability.dart',
+    )
+    ..add(
+      'debug',
+      (_) => DashbookGameWidget(game: Debug()),
+      codeLink:
+          'https://github.com/flame-engine/flame_example/blob/master/lib/stories/components/debug.dart',
+    );
 }

--- a/lib/stories/components/components.dart
+++ b/lib/stories/components/components.dart
@@ -3,19 +3,18 @@ import 'package:dashbook/dashbook.dart';
 import './composability.dart';
 import './debug.dart';
 import '../../commons/dashbook_gamewidget.dart';
+import '../../commons/commons.dart';
 
 void addComponentsStories(Dashbook dashbook) {
   dashbook.storiesOf('Components')
     ..add(
       'composability',
       (_) => DashbookGameWidget(game: Composability()),
-      codeLink:
-          'https://github.com/flame-engine/flame_example/blob/master/lib/stories/components/composability.dart',
+      codeLink: baseLink('components/composability.dart'),
     )
     ..add(
       'debug',
       (_) => DashbookGameWidget(game: Debug()),
-      codeLink:
-          'https://github.com/flame-engine/flame_example/blob/master/lib/stories/components/debug.dart',
+      codeLink: baseLink('components/debug.dart'),
     );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       name: dashbook
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.10"
+    version: "0.0.11"
   fake_async:
     dependency: transitive
     description:
@@ -81,6 +81,18 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3-nullsafety.3"
   matcher:
     dependency: transitive
     description:
@@ -109,6 +121,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0-nullsafety.3"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -163,6 +182,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.5"
+  url_launcher:
+    dependency: transitive
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.7.10"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+4"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+9"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.9"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5+1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+3"
   vector_math:
     dependency: transitive
     description:
@@ -172,4 +233,4 @@ packages:
     version: "2.1.0-nullsafety.5"
 sdks:
   dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.6.0 <2.0.0"
+  flutter: ">=1.22.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   flame: 1.0.0-rc5
-  dashbook: 0.0.10
+  dashbook: 0.0.11
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Adds a link on top of the examples so users can easily see the source code of the example.

On this example you will notice that I created a wrapper for the GameWidget. I did that because I messed up on the code link icon on Dashbook, I left it hardcoded to be black, but our background also is black, so it vanished.

For a next version of Dashbook, I will add another icon there, for information about the example, and will also add a property to customize the color of the icon, so I will do a follow up PR here to address that. 


https://user-images.githubusercontent.com/835641/104042826-b99ff680-51b9-11eb-9711-b8e43debe3cc.mov

